### PR TITLE
Add support for generics on component portmapping & add Natural and Positive types

### DIFF
--- a/src/generator/common/convert.rs
+++ b/src/generator/common/convert.rs
@@ -455,6 +455,8 @@ impl Multilane for Type {
                 Type::Bit => Ok(Type::BitVec {
                     width: element_lanes,
                 }),
+                Type::Natural => unimplemented!("natural currently not supported outside of generics"),
+                Type::Positive => unimplemented!("positive currently not supported outside of generics"),
                 Type::BitVec { width: _ } | Type::Record(_) | Type::Union(_) | Type::Array(_) => {
                     Ok(Type::array(
                         format!("{}_array", identity.into()),

--- a/src/generator/common/mod.rs
+++ b/src/generator/common/mod.rs
@@ -237,7 +237,7 @@ impl Array {
         let p: String = with.into();
         let new_name = cat!(self.identifier(), p);
         match self.typ() {
-            Type::Bit | Type::BitVec { width: _ } => {
+            Type::Bit | Type::Natural | Type::Positive | Type::BitVec { width: _ } => {
                 Array::new(new_name, self.typ().clone(), self.width())
             }
             Type::Record(rec) => Array::new(
@@ -275,6 +275,10 @@ pub enum Type {
         /// The width of the vector.
         width: NonNegative,
     },
+    /// Not implemented as hardware type only for generics
+    Natural,
+    /// Not implemented as hardware type only for generics
+    Positive,
     /// A record.
     Record(Record),
     /// Unions are implemented as records when using a "fancy" representation.

--- a/src/generator/vhdl/impls.rs
+++ b/src/generator/vhdl/impls.rs
@@ -81,6 +81,8 @@ fn declare_arr(arr: &Array) -> Result<String> {
 
     match arr.typ() {
         Type::Bit => return Err(BackEndError("Unexpected, Bit in Array".to_string())),
+        Type::Natural => return Err(BackEndError("Unexpected, Natural in Array".to_string())),
+        Type::Positive => return Err(BackEndError("Unexpected, Positive in Array".to_string())),
         Type::BitVec { width: _ } => this.push_str(arr.typ().declare(false)?.clone().as_str()),
         Type::Record(rec) => rec_declare_children(&mut children, rec.clone(), &mut this)?,
         Type::Union(rec) => rec_declare_children(&mut children, rec.clone(), &mut this)?,
@@ -145,6 +147,8 @@ impl DeclareType for Type {
     fn declare(&self, is_root_type: bool) -> Result<String> {
         match self {
             Type::Bit => Ok("std_logic".to_string()),
+            Type::Natural => Ok("natural".to_string()),
+            Type::Positive => Ok("positive".to_string()),
             Type::BitVec { width } => {
                 let actual_width = if *width == 0 { 1 } else { *width };
                 Ok(format!(
@@ -354,6 +358,8 @@ impl ListUsings for Package {
         fn uses_std_logic(t: &Type) -> bool {
             match t {
                 Type::Bit => true,
+                Type::Natural => false,
+                Type::Positive => false,
                 Type::BitVec { width: _ } => true,
                 Type::Record(rec) => rec.fields().any(|field| uses_std_logic(field.typ())),
                 Type::Union(rec) => rec.fields().any(|field| uses_std_logic(field.typ())),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -110,6 +110,8 @@ pub mod stdlib;
 pub type Positive = std::num::NonZeroU32;
 /// Non-negative integer.
 pub type NonNegative = u32;
+/// Natural integer as defined by VHDL.
+pub type Natural = NonNegative;
 /// Positive real.
 pub type PositiveReal = NonZeroReal<f64>;
 

--- a/src/stdlib/common/architecture/assignment/assignment_from.rs
+++ b/src/stdlib/common/architecture/assignment/assignment_from.rs
@@ -1,5 +1,7 @@
 use crate::stdlib::common::architecture::declaration::ObjectDeclaration;
 
+use crate::{Positive, Natural};
+
 use super::{
     array_assignment::ArrayAssignment, bitvec::BitVecValue, Assignment, AssignmentKind,
     DirectAssignment, ObjectAssignment, StdLogicValue, ValueAssignment,
@@ -72,6 +74,18 @@ impl From<ArrayAssignment> for DirectAssignment {
 impl From<StdLogicValue> for ValueAssignment {
     fn from(assignment: StdLogicValue) -> Self {
         ValueAssignment::Bit(assignment.into())
+    }
+}
+
+impl From<Natural> for ValueAssignment {
+    fn from(assignment: Natural) -> Self {
+        ValueAssignment::Integer(assignment.into())
+    }
+}
+
+impl From<Positive> for ValueAssignment {
+    fn from(assignment: Positive) -> Self {
+        ValueAssignment::Integer(assignment.into())
     }
 }
 

--- a/src/stdlib/common/architecture/assignment/flatten.rs
+++ b/src/stdlib/common/architecture/assignment/flatten.rs
@@ -41,6 +41,8 @@ impl FlatLength for ObjectType {
     fn flat_length(&self) -> Result<u32> {
         Ok(match self {
             ObjectType::Bit => 1,
+            ObjectType::Natural => unimplemented!("Length calculation for Natural not implemented, Natural only supported in generics for now"),
+            ObjectType::Positive => unimplemented!("Length calculation for Positive not implemented, Positive only supported in generics for now"),
             ObjectType::Array(arr) => arr.width() * arr.typ().flat_length()?,
             ObjectType::Record(rec) => {
                 let mut total: u32 = 0;
@@ -174,6 +176,8 @@ impl FlatAssignment for ObjectDeclaration {
             };
             match &self_typ {
                 ObjectType::Bit => finalize()?,
+                ObjectType::Natural => finalize()?,
+                ObjectType::Positive => finalize()?,
                 ObjectType::Array(arr) if arr.is_bitvector() => finalize()?,
                 ObjectType::Array(arr) => {
                     // If the length is 1, make the last range selection an index selection, or introduce an index selection

--- a/src/stdlib/common/architecture/assignment/impls.rs
+++ b/src/stdlib/common/architecture/assignment/impls.rs
@@ -17,6 +17,7 @@ impl ListUsings for AssignmentKind {
             AssignmentKind::Direct(direct) => match direct {
                 DirectAssignment::Value(value) => match value {
                     ValueAssignment::Bit(_) => (),
+                    ValueAssignment::Integer(_) => (),
                     ValueAssignment::BitVec(bitvec) => match bitvec {
                         BitVecValue::Others(_) => (),
                         BitVecValue::Full(_) => (),

--- a/src/stdlib/common/architecture/assignment/mod.rs
+++ b/src/stdlib/common/architecture/assignment/mod.rs
@@ -6,7 +6,7 @@ use indexmap::map::IndexMap;
 use array_assignment::ArrayAssignment;
 
 use crate::physical::Width;
-use crate::{Document, Error, Result};
+use crate::{Document, Error, Result, NonNegative};
 
 use super::declaration::ObjectDeclaration;
 use super::object::ObjectType;
@@ -186,6 +186,8 @@ impl AssignmentKind {
         let object = object.clone().into();
         match object.typ()? {
             ObjectType::Bit => Ok(object.into()),
+            ObjectType::Natural => Ok(object.into()),
+            ObjectType::Positive => Ok(object.into()),
             ObjectType::Record(rec) => {
                 let mut fields = IndexMap::new();
                 for (field, typ) in rec.fields() {
@@ -282,6 +284,7 @@ impl AssignmentKind {
             AssignmentKind::Direct(direct) => match direct {
                 DirectAssignment::Value(value) => match value {
                     ValueAssignment::Bit(bit) => Ok(format!("'{}'", bit)),
+                    ValueAssignment::Integer(integer) => Ok(integer.to_string()),
                     ValueAssignment::BitVec(bitvec) => Ok(bitvec.declare_for(object_identifier)),
                 },
                 DirectAssignment::FullRecord(record) => {
@@ -484,6 +487,8 @@ pub enum DirectAssignment {
 pub enum ValueAssignment {
     /// Assigning a value to a single bit
     Bit(StdLogicValue),
+    /// Assigning an unsigned integer value to a Natural or Positive
+    Integer(NonNegative),
     /// Assigning a value to a (part of) a bit vector
     BitVec(BitVecValue),
 }


### PR DESCRIPTION
The support for generics takes the parameters from a component and adds them to the portmapping as generics.

The Natural and Positive types are only meant to be used for generics because calculating the width of these types has not been implemented.